### PR TITLE
TCE-1548: Update default values for ccn issues

### DIFF
--- a/docs/description/ccn-critical.md
+++ b/docs/description/ccn-critical.md
@@ -1,3 +1,3 @@
 # Critical Cyclomatic Complexity control
 
-Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Critical issue. The default threshold is 20.
+Check the Cyclomatic Complexity value of a function or logic block. If the threshold is exceeded, raise a Critical issue. The default threshold is 20.

--- a/docs/description/ccn-critical.md
+++ b/docs/description/ccn-critical.md
@@ -1,3 +1,3 @@
 # Critical Cyclomatic Complexity control
 
-Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Critical issue. The default threshold is 10.
+Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Critical issue. The default threshold is 20.

--- a/docs/description/ccn-medium.md
+++ b/docs/description/ccn-medium.md
@@ -1,3 +1,3 @@
 # Medium Cyclomatic Complexity control
 
-Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Medium issue. The default threshold is 7.
+Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Medium issue. The default threshold is 15.

--- a/docs/description/ccn-medium.md
+++ b/docs/description/ccn-medium.md
@@ -1,3 +1,3 @@
 # Medium Cyclomatic Complexity control
 
-Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Medium issue. The default threshold is 15.
+Check the Cyclomatic Complexity value of a function or logic block. If the threshold is exceeded, raise a Medium issue. The default threshold is 15.

--- a/docs/description/ccn-minor.md
+++ b/docs/description/ccn-minor.md
@@ -1,3 +1,3 @@
 # Minor Cyclomatic Complexity control
 
-Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Minor issue. The default threshold is 10.
+Check the Cyclomatic Complexity value of a function or logic block. If the threshold is exceeded, raise a Minor issue. The default threshold is 10.

--- a/docs/description/ccn-minor.md
+++ b/docs/description/ccn-minor.md
@@ -1,3 +1,3 @@
 # Minor Cyclomatic Complexity control
 
-Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Minor issue. The default threshold is 4.
+Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Minor issue. The default threshold is 10.

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -44,7 +44,7 @@
     ],
     "patternId": "ccn-minor",
     "title": "Minor Cyclomatic Complexity control",
-    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Minor issue. The default threshold is 10.",
+    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is exceeded, raise a Minor issue. The default threshold is 10.",
     "timeToFix": 5
   },
   {

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -56,7 +56,7 @@
     ],
     "patternId": "ccn-medium",
     "title": "Medium Cyclomatic Complexity control",
-    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Medium issue. The default threshold is 15.",
+    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is exceeded, raise a Medium issue. The default threshold is 15.",
     "timeToFix": 5
   },
   {

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -44,7 +44,7 @@
     ],
     "patternId": "ccn-minor",
     "title": "Minor Cyclomatic Complexity control",
-    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Minor issue. The default threshold is 5.",
+    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Minor issue. The default threshold is 10.",
     "timeToFix": 5
   },
   {
@@ -56,7 +56,7 @@
     ],
     "patternId": "ccn-medium",
     "title": "Medium Cyclomatic Complexity control",
-    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Medium issue. The default threshold is 8.",
+    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Medium issue. The default threshold is 15.",
     "timeToFix": 5
   },
   {
@@ -68,7 +68,7 @@
     ],
     "patternId": "ccn-critical",
     "title": "Critical Cyclomatic Complexity control",
-    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Critical issue. The default threshold is 12.",
+    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Critical issue. The default threshold is 20.",
     "timeToFix": 5
   },
   {

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -68,7 +68,7 @@
     ],
     "patternId": "ccn-critical",
     "title": "Critical Cyclomatic Complexity control",
-    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is not met, raise a Critical issue. The default threshold is 20.",
+    "description": "Check the Cyclomatic Complexity value of a function or logic block. If the threshold is exceeded, raise a Critical issue. The default threshold is 20.",
     "timeToFix": 5
   },
   {

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -45,10 +45,10 @@
       "parameters": [
         {
           "name": "threshold",
-          "default": 5
+          "default": 10
         }
       ],
-      "enabled": false
+      "enabled": true
     },
     {
       "patternId": "ccn-medium",
@@ -57,10 +57,10 @@
       "parameters": [
         {
           "name": "threshold",
-          "default": 8
+          "default": 15
         }
       ],
-      "enabled": true
+      "enabled": false
     },
     {
       "patternId": "ccn-critical",
@@ -69,7 +69,7 @@
       "parameters": [
         {
           "name": "threshold",
-          "default": 12
+          "default": 20
         }
       ],
       "enabled": false


### PR DESCRIPTION
## Summary

Updates the default values for the Cyclomatic Complexity (`ccn`) issues in `docs/patterns.json` as requested in [TCE-1548](https://codacy.atlassian.net/browse/TCE-1548).

| Pattern | Threshold (before → after) | Enabled (before → after) |
|---|---|---|
| `ccn-minor` | 5 → **10** | false → **true** |
| `ccn-medium` | 8 → **15** | true → **false** |
| `ccn-critical` | 12 → **20** | false → false (unchanged) |

Only `ccn-minor` is enabled by default now.

## Changes

- **`docs/patterns.json`** — the canonical source of the defaults; thresholds and `enabled` flags updated as above.
- **`docs/description/description.json`** — the ccn pattern descriptions reference the default thresholds ("The default threshold is …"); updated 5→10, 8→15, 12→20 to stay in sync.
- **`docs/description/ccn-{minor,medium,critical}.md`** — same description text. ⚠️ These files previously carried **stale** values (4 / 7 / 10) that did not match `patterns.json` (5 / 8 / 12) — a pre-existing inconsistency. They are now aligned to the new defaults (10 / 15 / 20).

The `docs/multiple-tests/all-patterns/patterns.xml` integration fixture uses **explicit** thresholds (not the defaults), so it is intentionally left unchanged and the tests still pass.

## codacy-tools validation checklist

### Step 1 — Dependency vulnerability scan (trivy)
```
trivy fs --exit-code 0 --severity HIGH,CRITICAL .
```
Result: **0 HIGH/CRITICAL** vulnerabilities in `package-lock.json`. No new vulnerabilities introduced by this change.

> Note: GitHub/Dependabot reports vulnerabilities on the default branch (1 high, 4 moderate, 2 low). These are pre-existing and unrelated to this docs-only change; trivy's `fs` scan of the dependency lockfile reports clean for HIGH/CRITICAL.

### Step 2 — Pattern/docs generation
The `README.md` does not document any pattern/docs generation command (the "Docs" section only links to external developer guides; `package.json` scripts are `build`/`lint`/`test`/`upgrade` only). The docs under `docs/` are hand-maintained, so this step has no command to run and was skipped.

### Step 3 — Integration test with codacy-plugins-test
Tool name (per README / `src/toolMetadata.ts`): **`lizard`**. Built the docker image locally (`codacy/codacy-lizard:latest`) and ran the test suite:

`multiple`:
```
[MultipleTests] Running MultipleTests:
[MultipleTests] all-patterns should have 3 results
[ResultPrinter] Got 3 results.
[DockerTest] [Success] MultipleTests$
[DockerTest] [Success] All tests passed!
```

`json` (extra check, since the change touches `patterns.json` + `description.json`):
```
[JsonTests] Read /docs/patterns.json successfully
[JsonTests] Read /docs/description/description.json successfully
[JsonTests] Read /docs/description/ccn-critical.md successfully
[JsonTests] Read /docs/description/ccn-medium.md successfully
[JsonTests] Read /docs/description/ccn-minor.md successfully
[DockerTest] [Success] JsonTests$
[DockerTest] [Success] All tests passed!
```
(The `file-nloc-*.md` "could not read" lines are pre-existing — those description files do not exist — and are unrelated to this change; the test still passes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TCE-1548]: https://codacy.atlassian.net/browse/TCE-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ